### PR TITLE
Removes Translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,3 @@ func <|< <A>(lhs: A, rhs: A) -> A
 ```
 
 _Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
-
-#### Translations
-
-* [中文版](https://github.com/Artwalk/swift-style-guide/blob/master/README_CN.md)
-* [日本語版](https://github.com/jarinosuke/swift-style-guide/blob/master/README_JP.md)


### PR DESCRIPTION
I went ahead and removed the 'Translations' section as we are not able to keep those updated. Also, as this is a private repository and thus a private style guide we won't need the translations.
